### PR TITLE
rag-svelte api: starlette 1.0.1->1.3.1 (GHSA-82w8-qh3p-5jfq +3) [superseded by #1782]

### DIFF
--- a/samples/rag-document-qa-svelte/api/uv.lock
+++ b/samples/rag-document-qa-svelte/api/uv.lock
@@ -707,15 +707,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602344Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017643Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## `[auto-sec]` Canonical — aspire-samples Python `starlette` remediation

**Cluster:** Python/pip `starlette` advisories in `samples/rag-document-qa-svelte/api/uv.lock`
(breaking major bump, kept separate from the npm batch #1782).
**Branch:** `dapire/security-deps/aspire-samples-python-starlette` (rebased on latest `origin/main`).
**Label:** `automated-security`.

### Alerts addressed (4)
| GHSA | Severity | Vulnerable | Fixed |
|---|---|---|---|
| GHSA-82w8-qh3p-5jfq | high | `>= 0.4.1, < 1.3.1` | 1.3.1 |
| GHSA-jp82-jpqv-5vv3 | low | `< 1.3.0` | 1.3.0 |
| GHSA-wqp7-x3pw-xc5r | high | `< 1.1.0` | 1.1.0 |
| GHSA-x746-7m8f-x49c | medium | `< 1.1.0` | 1.1.0 |

### Remediation
- `starlette` bumped **1.0.1 → 1.3.1** in `rag-document-qa-svelte/api/uv.lock`. `1.3.1` is the highest
  first-patched version across the four advisories, so it clears **all** of them.
- Verified: `uv.lock` now pins `starlette == 1.3.1`. Diff is scoped to this single lock file (rebased so the
  only delta vs `main` is the starlette entry).

### Verification / CI status
- **windows-latest: pass.** `license/cla`: pass.
- **ubuntu-latest: fail — NOT caused by this change.** The failure is `Aspire.Hosting.DistributedApplicationException:
  Resource 'angular' failed to start` while the full-sample build runs `npm ci` for the unrelated
  `AspireJavaScript.Angular` sample. This is the **pre-existing, repo-wide Angular dependency-resolution
  problem** that is remediated in **#1782** (Angular `typescript`/`@angular-devkit` peer alignment + npm
  overrides). It is orthogonal to the Python `starlette` change here (windows, which runs the same samples,
  passes; the Python service builds fine).

### Blocker & sequencing
- This PR is **mergeable** and the security change is complete/verified. Its ubuntu CI cannot go green
  independently because the Angular fix lives in the separate npm cluster PR **#1782** (one-canonical-per-cluster).
- **Recommended order:** land **#1782** first, then re-run CI here (or rebase) — ubuntu will pass once main
  contains the Angular remediation. Kept open until then; not auto-merging.


### Re-verified 2026-08-11
- Re-ran the failed ubuntu job (run `31386342553`): **failed identically** (17m18s).
- Exact root cause captured from the job log: `npm error code ERESOLVE` while resolving
  `@angular-devkit/build-angular@22.0.8` against `typescript@7.0.2` — the Angular sample declares
  `typescript: ~7.0.2`, which angular-devkit 22.0.8 does not accept as a peer, so strict `npm ci` aborts.
- Canonical **#1782** pins `typescript@6.0.3` in that same lockfile (verified on its branch), which resolves
  cleanly and is why #1782's ubuntu build is green. Confirms #1873 is blocked **solely** by the main-level
  Angular defect, not by the `starlette` change. No rebase onto current `main` can fix it until #1782 lands.
