### PR TITLE
Update all samples to Aspire 13.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  ASPIRE_CLI_VERSION: '13.4.6'
+  ASPIRE_CLI_VERSION: '13.5.0'
   NODE_VERSION: '24.18.0'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         global-json-file: ./build/global.json
     
     - name: Print .NET info
+      working-directory: ./build
       run: dotnet --info
 
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -105,6 +106,7 @@ jobs:
       # Trusting certs on Windows throws a prompt so will halt the build
       if: runner.os == 'Linux'
       shell: bash
+      working-directory: ./build
       run: |
         trust_dir="$HOME/.aspnet/dev-certs/trust"
         echo "SSL_CERT_DIR=$trust_dir:/usr/lib/ssl/certs" >> "$GITHUB_ENV"
@@ -117,11 +119,13 @@ jobs:
 
     - name: Build (Ubuntu)
       if: runner.os == 'Linux'
-      run: ./build/build.sh -p:SkipTypeScriptRestore=true
+      working-directory: ./build
+      run: ./build.sh -p:SkipTypeScriptRestore=true
 
     - name: Build (Windows)
       if: runner.os == 'Windows'
-      run: .\build\build.cmd
+      working-directory: ./build
+      run: .\build.cmd
 
     - name: Copy binlog files
       if: always()
@@ -155,11 +159,12 @@ jobs:
       # We only test on Ubuntu because Windows agents don't support Docker with WSL
       if: runner.os == 'Linux'
       timeout-minutes: 20
+      working-directory: ./tests
       # Note that the space after the last double dash (--) is intentional
       run: >
-        dotnet test ./tests/SamplesTests.slnx
+        dotnet test ./SamplesTests.slnx
         --logger console --logger trx --logger GitHubActions
-        --results-directory ./TestResults --blame
+        --results-directory ../TestResults --blame
         -- 
         RunConfiguration.CollectSourceInformation=true
 

--- a/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
+++ b/samples/Metrics/MetricsApp.AppHost/MetricsApp.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\MetricsApp\MetricsApp.csproj" />
   </ItemGroup>

--- a/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/samples/aspire-shop/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\AspireShop.BasketService\AspireShop.BasketService.csproj" />
     <ProjectReference Include="..\AspireShop.CatalogDbManager\AspireShop.CatalogDbManager.csproj" />

--- a/samples/aspire-shop/AspireShop.BasketService/AspireShop.BasketService.csproj
+++ b/samples/aspire-shop/AspireShop.BasketService/AspireShop.BasketService.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.83.0" />
     <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.83.0" />
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/aspire-shop/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.6" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.5.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
   </ItemGroup>
 

--- a/samples/aspire-shop/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
+++ b/samples/aspire-shop/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.6" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/aspire-with-azure-functions/Directory.Packages.props
+++ b/samples/aspire-with-azure-functions/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure" Version="13.5.0" />
     <!-- Aspire Hosting -->
-    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Azure.Functions" Version="13.5.0" />
     <!-- Aspire Azure -->
-    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="13.5.0" />
     <!-- Azure Functions -->
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.1" />

--- a/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
+++ b/samples/aspire-with-azure-functions/ImageGallery.AppHost/ImageGallery.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
+++ b/samples/aspire-with-javascript/AspireJavaScript.AppHost/AspireJavaScript.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\AspireJavaScript.MinimalApi\AspireJavaScript.MinimalApi.csproj" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.5.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/aspire-with-node/aspire.config.json
+++ b/samples/aspire-with-node/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -24,6 +24,6 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.JavaScript": "13.4.0"
+    "Aspire.Hosting.JavaScript": "13.5.0"
   }
 }

--- a/samples/aspire-with-python/apphost.cs
+++ b/samples/aspire-with-python/apphost.cs
@@ -1,7 +1,7 @@
-#:sdk Aspire.AppHost.Sdk@13.4.6
-#:package Aspire.Hosting.JavaScript@13.4.6
-#:package Aspire.Hosting.Python@13.4.6
-#:package Aspire.Hosting.Redis@13.4.6
+#:sdk Aspire.AppHost.Sdk@13.5.0
+#:package Aspire.Hosting.JavaScript@13.5.0
+#:package Aspire.Hosting.Python@13.5.0
+#:package Aspire.Hosting.Redis@13.5.0
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/samples/client-apps-integration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
+++ b/samples/client-apps-integration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\ClientAppsIntegration.ApiService\ClientAppsIntegration.ApiService.csproj" />
     <ProjectReference Include="..\ClientAppsIntegration.WinForms\ClientAppsIntegration.WinForms.csproj" />

--- a/samples/container-build/apphost.cs
+++ b/samples/container-build/apphost.cs
@@ -1,4 +1,4 @@
-#:sdk Aspire.AppHost.Sdk@13.4.6
+#:sdk Aspire.AppHost.Sdk@13.5.0
 
 using Microsoft.Extensions.Hosting;
 

--- a/samples/custom-resources/CustomResources.AppHost/CustomResources.AppHost.csproj
+++ b/samples/custom-resources/CustomResources.AppHost/CustomResources.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
     <UserSecretsId>00d08ee4-b2e0-4d12-827c-d131fda1c6f6</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
   </ItemGroup>
 

--- a/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
+++ b/samples/database-containers/DatabaseContainers.ApiService/DatabaseContainers.ApiService.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.4.6" />
-    <PackageReference Include="Aspire.Npgsql" Version="13.4.6" />
-    <PackageReference Include="Aspire.MySqlConnector" Version="13.4.6" />
+    <PackageReference Include="Aspire.Microsoft.Data.SqlClient" Version="13.5.0" />
+    <PackageReference Include="Aspire.Npgsql" Version="13.5.0" />
+    <PackageReference Include="Aspire.MySqlConnector" Version="13.5.0" />
     <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />

--- a/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
+++ b/samples/database-containers/DatabaseContainers.AppHost/DatabaseContainers.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.MySql" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.MySql" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
   </ItemGroup>
 

--- a/samples/database-migrations/DatabaseMigrations.ApiService/DatabaseMigrations.ApiService.csproj
+++ b/samples/database-migrations/DatabaseMigrations.ApiService/DatabaseMigrations.ApiService.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.5.0" />
 
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />

--- a/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
+++ b/samples/database-migrations/DatabaseMigrations.AppHost/DatabaseMigrations.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\DatabaseMigrations.ApiService\DatabaseMigrations.ApiService.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.MigrationService\DatabaseMigrations.MigrationService.csproj" />

--- a/samples/database-migrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
+++ b/samples/database-migrations/DatabaseMigrations.MigrationService/DatabaseMigrations.MigrationService.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.5.0" />
     <ProjectReference Include="..\DatabaseMigrations.ApiModel\DatabaseMigrations.ApiModel.csproj" />
     <ProjectReference Include="..\DatabaseMigrations.ServiceDefaults\DatabaseMigrations.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/samples/golang-api/aspire.config.json
+++ b/samples/golang-api/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,6 +16,6 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
+++ b/samples/health-checks-ui/HealthChecksUI.AppHost/HealthChecksUI.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
   </ItemGroup>
 

--- a/samples/health-checks-ui/HealthChecksUI.Web/HealthChecksUI.Web.csproj
+++ b/samples/health-checks-ui/HealthChecksUI.Web/HealthChecksUI.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.4.6" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.5.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
   </ItemGroup>
 

--- a/samples/image-gallery/api/api.csproj
+++ b/samples/image-gallery/api/api.csproj
@@ -17,9 +17,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.0" />
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.4.0" />
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.5.0" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.5.0" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.5.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />

--- a/samples/image-gallery/apphost.cs
+++ b/samples/image-gallery/apphost.cs
@@ -1,11 +1,11 @@
 #pragma warning disable ASPIRECSHARPAPPS001
 #pragma warning disable ASPIREAZURE002
 
-#:sdk Aspire.AppHost.Sdk@13.4.6
-#:package Aspire.Hosting.Azure.Storage@13.4.6
-#:package Aspire.Hosting.Azure.Sql@13.4.6
-#:package Aspire.Hosting.JavaScript@13.4.6
-#:package Aspire.Hosting.Azure.AppContainers@13.4.6
+#:sdk Aspire.AppHost.Sdk@13.5.0
+#:package Aspire.Hosting.Azure.Storage@13.5.0
+#:package Aspire.Hosting.Azure.Sql@13.5.0
+#:package Aspire.Hosting.JavaScript@13.5.0
+#:package Aspire.Hosting.Azure.AppContainers@13.5.0
 
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.AppContainers;

--- a/samples/image-gallery/worker/worker.csproj
+++ b/samples/image-gallery/worker/worker.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.0" />
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.4.0" />
-    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.4.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.5.0" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.5.0" />
+    <PackageReference Include="Aspire.Azure.Storage.Queues" Version="13.5.0" />
     <PackageReference Include="SkiaSharp" Version="3.119.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.1" />
   </ItemGroup>

--- a/samples/maildev-mailkit/CSharpAppHost/CSharpAppHost.csproj
+++ b/samples/maildev-mailkit/CSharpAppHost/CSharpAppHost.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/maildev-mailkit/MailDev.Hosting/MailDev.Hosting.csproj
+++ b/samples/maildev-mailkit/MailDev.Hosting/MailDev.Hosting.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting" Version="13.5.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/maildev-mailkit/aspire.config.json
+++ b/samples/maildev-mailkit/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "packages": {
     "MailDev.Hosting": "MailDev.Hosting/MailDev.Hosting.csproj"

--- a/samples/node-express-redis/aspire.config.json
+++ b/samples/node-express-redis/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,9 +16,9 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.JavaScript": "13.4.0",
-    "Aspire.Hosting.Redis": "13.4.0",
-    "Aspire.Hosting.Yarp": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.JavaScript": "13.5.0",
+    "Aspire.Hosting.Redis": "13.5.0",
+    "Aspire.Hosting.Yarp": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
+++ b/samples/orleans-voting/OrleansVoting.AppHost/OrleansVoting.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Orleans" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\OrleansVoting.Service\OrleansVoting.Service.csproj" />
   </ItemGroup>

--- a/samples/orleans-voting/OrleansVoting.Service/OrleansVoting.Service.csproj
+++ b/samples/orleans-voting/OrleansVoting.Service/OrleansVoting.Service.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.4.6" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.5.0" />
 
     <PackageReference Include="Microsoft.Orleans.Clustering.Redis" Version="10.2.2" />
     <PackageReference Include="Microsoft.Orleans.Persistence.Redis" Version="10.2.2" />

--- a/samples/polyglot-task-queue/aspire.config.json
+++ b/samples/polyglot-task-queue/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,9 +16,9 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.RabbitMQ": "13.4.0",
-    "Aspire.Hosting.Python": "13.4.0",
-    "Aspire.Hosting.JavaScript": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.RabbitMQ": "13.5.0",
+    "Aspire.Hosting.Python": "13.5.0",
+    "Aspire.Hosting.JavaScript": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/polyglot-task-queue/worker-csharp/worker-csharp.csproj
+++ b/samples/polyglot-task-queue/worker-csharp/worker-csharp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.RabbitMQ.Client" Version="13.4.0" />
+    <PackageReference Include="Aspire.RabbitMQ.Client" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 

--- a/samples/python-fastapi-postgres/aspire.config.json
+++ b/samples/python-fastapi-postgres/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,8 +16,8 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.Python": "13.4.0",
-    "Aspire.Hosting.PostgreSQL": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.Python": "13.5.0",
+    "Aspire.Hosting.PostgreSQL": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/python-openai-agent/aspire.config.json
+++ b/samples/python-openai-agent/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,8 +16,8 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.Python": "13.4.0",
-    "Aspire.Hosting.OpenAI": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.Python": "13.5.0",
+    "Aspire.Hosting.OpenAI": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/python-script/aspire.config.json
+++ b/samples/python-script/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,6 +16,6 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.Python": "13.4.0"
+    "Aspire.Hosting.Python": "13.5.0"
   }
 }

--- a/samples/rag-document-qa-svelte/aspire.config.json
+++ b/samples/rag-document-qa-svelte/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,9 +16,9 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.Python": "13.4.0",
-    "Aspire.Hosting.JavaScript": "13.4.0",
-    "Aspire.Hosting.Qdrant": "13.4.0",
-    "Aspire.Hosting.OpenAI": "13.4.0"
+    "Aspire.Hosting.Python": "13.5.0",
+    "Aspire.Hosting.JavaScript": "13.5.0",
+    "Aspire.Hosting.Qdrant": "13.5.0",
+    "Aspire.Hosting.OpenAI": "13.5.0"
   }
 }

--- a/samples/vite-csharp-postgres/api/Api.csproj
+++ b/samples/vite-csharp-postgres/api/Api.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.4.0" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.5.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.11" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />

--- a/samples/vite-csharp-postgres/aspire.config.json
+++ b/samples/vite-csharp-postgres/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,8 +16,8 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.PostgreSQL": "13.4.0",
-    "Aspire.Hosting.JavaScript": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.PostgreSQL": "13.5.0",
+    "Aspire.Hosting.JavaScript": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/vite-react-fastapi/aspire.config.json
+++ b/samples/vite-react-fastapi/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,9 +16,9 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.Python": "13.4.0",
-    "Aspire.Hosting.JavaScript": "13.4.0",
-    "Aspire.Hosting.Yarp": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.Python": "13.5.0",
+    "Aspire.Hosting.JavaScript": "13.5.0",
+    "Aspire.Hosting.Yarp": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/vite-yarp-static/aspire.config.json
+++ b/samples/vite-yarp-static/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.4.0"
+    "version": "13.5.0"
   },
   "profiles": {
     "https": {
@@ -16,8 +16,8 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.JavaScript": "13.4.0",
-    "Aspire.Hosting.Yarp": "13.4.0",
-    "Aspire.Hosting.Docker": "13.4.0"
+    "Aspire.Hosting.JavaScript": "13.5.0",
+    "Aspire.Hosting.Yarp": "13.5.0",
+    "Aspire.Hosting.Docker": "13.5.0"
   }
 }

--- a/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
+++ b/samples/volume-mount/VolumeMount.AppHost/VolumeMount.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <ProjectReference Include="..\VolumeMount.BlazorWeb\VolumeMount.BlazorWeb.csproj" />
     <ProjectReference Include="..\VolumeMount.MigrationService\VolumeMount.MigrationService.csproj" />

--- a/samples/volume-mount/VolumeMount.BlazorWeb/VolumeMount.BlazorWeb.csproj
+++ b/samples/volume-mount/VolumeMount.BlazorWeb/VolumeMount.BlazorWeb.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.4.6" />
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="13.5.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.11" />
   </ItemGroup>
 

--- a/samples/volume-mount/VolumeMount.MigrationService/VolumeMount.MigrationService.csproj
+++ b/samples/volume-mount/VolumeMount.MigrationService/VolumeMount.MigrationService.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.4.6" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
+++ b/tests/SamplesIntegrationTests/SamplesIntegrationTests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Azure" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Python" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Python" Version="13.5.0" />
 
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Sweeping update of every sample to the **Aspire 13.5.0** release — C# and TypeScript/JS AppHosts alike — plus the integration tests and the CI Aspire CLI pin. Clean one-for-one bump (42 files, 114 insertions / 114 deletions).

Follows #1891 (MailDev + MailKit custom integration sample), which has merged to `main`; the new `maildev-mailkit` sample is bumped along with the rest for consistency.

## Changes
- **C# projects** — `Aspire.AppHost.Sdk` and all `Aspire.*` `PackageReference` / `PackageVersion` entries: `13.4.6` → `13.5.0`.
- **TypeScript / JS AppHosts** — `aspire.config.json` `sdk.version` and `packages`: `13.4.0` → `13.5.0`.
- **maildev-mailkit** sample: `13.4.0` → `13.5.0`.
- **tests/SamplesIntegrationTests** — `Aspire.Hosting.*`: `13.4.6` → `13.5.0`.
- **CI** (`.github/workflows/ci.yml`) — `ASPIRE_CLI_VERSION`: `13.4.6` → `13.5.0`.

## CI status
`13.5.0` publishes to nuget.org and the `aspire` CLI install feed as part of **13.5 GA, which is rolling out now**. Until the packages and CLI finish propagating, CI will be **red** — the pinned CLI and the `13.5.0` packages aren't on nuget.org yet. No staging feed/channel was added; this intentionally targets nuget.org only. Once GA propagation completes, **re-run the failed CI checks** and they should go green.

Verified locally against the release feed that `Aspire.AppHost.Sdk/13.5.0` and the `Aspire.Hosting.*` / component packages resolve at `13.5.0`.